### PR TITLE
Added UTF-8 support for RC files

### DIFF
--- a/lib/googlecloudsdk/core/platforms_install.py
+++ b/lib/googlecloudsdk/core/platforms_install.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
+import io
 import os
 import re
 import shutil
@@ -196,7 +197,7 @@ class _RcUpdater(object):
 
       # Check whether RC file is a file and store its contents.
       if os.path.isfile(self.rc_path):
-        with open(self.rc_path) as rc_file:
+        with io.open(self.rc_path, mode='r', encoding='utf-8') as rc_file:
           rc_contents = rc_file.read()
           original_rc_contents = rc_contents
       elif os.path.exists(self.rc_path):
@@ -243,7 +244,7 @@ class _RcUpdater(object):
         return
 
       try:
-        with open(self.rc_path, 'w') as rc_file:
+        with io.open(self.rc_path, mode='w', encoding='utf-8') as rc_file:
           rc_file.write(rc_contents)
       except (files.Error, IOError, OSError):
         _TraceAction(


### PR DESCRIPTION
_NOTE: This is a mirrored repository, please advise for a better location for PRs. Additionally, I couldn't find a contribution guide._

Problem: Updating RC file failed when installing the Google Cloud SDK

Background: An RC file that contains non-ASCII characters causes the the Google Cloud SDK installer to fail. The `open()` function in Python 2.7 doesn't allow for a specified encoding. 

Solution: Use the `open()` function from the `io` module to read from and write to the RC file using UTF-8 encoding. This is the same function used in Python 3+.