### PR TITLE
Fix spurious warnings about missing executables

### DIFF
--- a/lib/surface/auth/configure_docker.py
+++ b/lib/surface/auth/configure_docker.py
@@ -51,14 +51,14 @@ class ConfigureDocker(base.Command):
 
   def Run(self, args):
     """Run the configure-docker command."""
-    if not file_utils.SearchForExecutableOnPath('docker-credential-gcloud'):
+    if not file_utils.FindExecutableOnPath('docker-credential-gcloud'):
       log.warning('`docker-credential-gcloud` not in system PATH.\n'
                   'gcloud\'s Docker credential helper can be configured but '
                   'it will not work until this is corrected.')
 
     current_config = cred_utils.Configuration.ReadFromDisk()
 
-    if file_utils.SearchForExecutableOnPath('docker'):
+    if file_utils.FindExecutableOnPath('docker'):
       if not current_config.SupportsRegistryHelpers():
         raise ConfigureDockerError(
             'Invalid Docker version: The version of your Docker client is '


### PR DESCRIPTION
SearchForExecutablesOnPath does not find docker-credential-gcloud with the .cmd
extension and docker with the .exe extension on Windows. Gcloud will output the
following spurious warning:

    > google auth configure-docker
    WARNING: `docker-credential-gcloud` not in system PATH.
    gcloud's Docker credential helper can be configured but it will not work until this is corrected.
    WARNING: `docker` not in system PATH.
    `docker` and `docker-credential-gcloud` need to be in the same PATH in order to work correctly together.
    gcloud's Docker credential helper can be configured but it will not work until this is corrected.

Use FindExecutablesOnPath instead, which searches for all extensions on a given
platform.