### PR TITLE
Only ignore root ".gitignore" file

### DIFF
--- a/lib/googlecloudsdk/command_lib/util/gcloudignore.py
+++ b/lib/googlecloudsdk/command_lib/util/gcloudignore.py
@@ -60,7 +60,7 @@ DEFAULT_IGNORE_FILE = """\
 # from your .gitignore file, remove the corresponding line
 # below:
 .git
-.gitignore
+/.gitignore
 """
 _GCLOUDIGNORE_PATH_SEP = '/'
 _ENDS_IN_ODD_NUMBER_SLASHES_RE = r'(?<!\\)\\(\\\\)*$'


### PR DESCRIPTION
".gitignore" files are often used as placeholders to keep an empty directory. If we ignore them, then directories won't be present in the Build environment, which may cause unexpected behavior. This proposal only ignores root .gitignores.